### PR TITLE
Setting the default value for including system variables to true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ build
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+config/
+config-test/
+plugins/
+plugins-test/
+system-test/

--- a/src/main/kotlin/io/kotlintest/plugin/intellij/KotlinTestRunConfiguration.kt
+++ b/src/main/kotlin/io/kotlintest/plugin/intellij/KotlinTestRunConfiguration.kt
@@ -29,7 +29,7 @@ class KotlinTestRunConfiguration(name: String, configurationFactory: Configurati
   private var alternativeJrePath: String? = ""
   private var alternativeJrePathEnabled = false
   private var envs = mutableMapOf<String, String>()
-  private var passParentEnvs: Boolean = false
+  private var passParentEnvs: Boolean = true
   private var programParameters: String? = null
   private var vmParameters: String? = ""
   private var workingDirectory: String? = null


### PR DESCRIPTION
Aimed at fixing #27, setting the system variables to be included by default.